### PR TITLE
Add TagBot and CompatHelper GitHub Actions workflows

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,37 @@
+name: CompatHelper
+on:
+  schedule:
+    - cron: 0 0 * * *
+  workflow_dispatch:
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if Julia is already available in the PATH
+        id: julia_in_path
+        run: which julia
+        continue-on-error: true
+      - name: Install Julia, but only if it is not already available in the PATH
+        uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+          arch: ${{ runner.arch }}
+        if: steps.julia_in_path.outcome != 'success'
+      - name: "Add the General registry via Git"
+        run: |
+          import Pkg
+          ENV["JULIA_PKG_SERVER"] = ""
+          Pkg.Registry.add("General")
+        shell: julia --color=yes {0}
+      - name: "Install CompatHelper"
+        run: import Pkg; Pkg.add("CompatHelper")
+        shell: julia --color=yes {0}
+      - name: "Run CompatHelper"
+        run: import CompatHelper; CompatHelper.main()
+        shell: julia --color=yes {0}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,31 @@
+name: TagBot
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      lookback:
+        default: "3"
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  deployments: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
## Summary
Adds the two standard Julia CI workflows so releases and dependency bumps are automated going forward.

- **TagBot** (`.github/workflows/TagBot.yml`) — once a version is registered in the General registry, auto-creates the matching git tag (e.g. `v1.1.1`) and a GitHub release. Driven by the Julia TagBot GitHub App's trigger comment; also runnable via `workflow_dispatch`.
- **CompatHelper** (`.github/workflows/CompatHelper.yml`) — runs daily, opens PRs to bump `[compat]` bounds as dependencies (`NearestNeighbors`, `SpecialFunctions`, …) release new versions.

Uses current standard templates (`julia-actions/setup-julia@v2`, `JuliaRegistries/TagBot@v1`). The `DOCUMENTER_KEY` / `COMPATHELPER_PRIV` secret references are optional — TagBot still tags and releases without them.

## Context
`Project.toml` is already at `1.1.1` on `main`, but the General registry only has up to `1.1.0`. Landing these workflows on the default branch before registering `1.1.1` ensures TagBot picks up the new version and tags it.

## Follow-ups (not in this PR)
- Ensure the [Julia TagBot GitHub App](https://github.com/apps/julia-tagbot) is installed on the `Entropy-Invariant` org.
- Register `1.1.1` (`@JuliaRegistrator register` on the release commit, or via JuliaHub Registrator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)